### PR TITLE
when a file isnt found, should throw

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: vecxx
-  version: 0.0.3
+  version: 0.0.4
 
 source:
   path: ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   host:
     - python
     - pip
-    - pybind11 >=2.5.0
+    - pybind11 >=2.8.0
 
   run:
     - python

--- a/include/vecxx/bpe.h
+++ b/include/vecxx/bpe.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <algorithm>
 #include <functional>
+#include <exception>
 #include "vecxx/utils.h"
 #include "vecxx/iox.h"
 #include "vecxx/phf.h"
@@ -213,9 +214,13 @@ void read_codes_file(const std::string& infile, Codes_T*& codes, RevCodes_T*& re
 	read_codes_mmap(infile, codes, rev_codes);
 	return;
     }
+
     auto c = new UnorderedMapStrInt();
     auto rc = new UnorderedMapStrStr();
     std::ifstream f(infile.c_str());
+    if (!f.is_open()) {
+        throw std::runtime_error(std::string("No file: ") + infile);
+    }
     std::string line;
     while (getline(f, line)) {
 	auto splits = split(line);
@@ -224,6 +229,7 @@ void read_codes_file(const std::string& infile, Codes_T*& codes, RevCodes_T*& re
 	(*c)[pair] = (uint32_t)c->size();
 	(*rc)[concat] = pair;
     }
+    f.close();
     codes = c;
     rev_codes = rc;
 }

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <functional>
-
+#include <exception>
 #include "vecxx/utils.h"
 #include "vecxx/bpe.h"
 
@@ -29,6 +29,9 @@ MapStrInt* read_vocab_file(const std::string& infile, int offset=4)
 	return read_vocab_mmap(infile);
     }
     std::ifstream f(infile.c_str());
+    if (!f.is_open()) {
+        throw std::runtime_error(std::string("No file: ") + infile);
+    }
     std::string line;
     int i = 0;
     UnorderedMapStrInt* vocab = new UnorderedMapStrInt();
@@ -40,6 +43,7 @@ MapStrInt* read_vocab_file(const std::string& infile, int offset=4)
 
 	
     }
+    f.close();
     return vocab;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vecxx",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vecxx",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "C++ implementations of vectorizers",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'pybind11>=2.5.0']
+requires = ['setuptools', 'wheel', 'pybind11>=2.8.0']
+
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     author=About.AUTHOR,
     python_requires='>=3.6',
     ext_modules=ext_modules,
-    install_requires=["pybind11>=2.5.0"],
+    install_requires=["pybind11>=2.8.0"],
     extras_require={
         'test': ['pytest', 'pytest-forked'],
     },

--- a/setup.py
+++ b/setup.py
@@ -1,111 +1,43 @@
 import sys
-import setuptools
-from setuptools import setup, Extension
-from setuptools.command.build_ext import build_ext
-import pybind11
 
+# Available at setup time due to pyproject.toml
+from pybind11.setup_helpers import Pybind11Extension, build_ext
+from setuptools import setup
 
 __version__ = "0.0.4"
 
-
-class About(object):
-    NAME="vecxx"
-    VERSION=__version__
-    AUTHOR="dpressel"
-    DESCRIPTION="vectorize some text"
-
+# The main interface is through Pybind11Extension.
+# * You can add cxx_std=11/14/17, and then build_ext can be removed.
+# * You can set include_pybind11=false to add the include directory yourself,
+#   say from a submodule.
+#
+# Note:
+#   Sort input source files if you glob sources to ensure bit-for-bit
+#   reproducible builds (https://github.com/pybind/python_example/pull/53)
 
 ext_modules = [
-    Extension(
-        'vecxx',
-        ['src/vecxx.cpp'],
-        include_dirs=[
-            'include/',
-            pybind11.get_include(False),
-            pybind11.get_include(True)
-        ],
-        language="c++"
-    )
+    Pybind11Extension("vecxx",
+        ["src/vecxx.cpp"],
+        include_dirs=["include"],
+        define_macros = [('VERSION_INFO', __version__)],
+        ),
 ]
 
-
-# As of Python 3.6, CCompiler has a `has_flag` method.
-# cf http://bugs.python.org/issue26689
-def has_flag(compiler, flagname):
-    """Return a boolean indicating whether a flag name is supported on
-    the specified compiler.
-    """
-    import tempfile
-    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
-        f.write('int main (int argc, char **argv) { return 0; }')
-        try:
-            compiler.compile([f.name], extra_postargs=[flagname])
-        except setuptools.distutils.errors.CompileError:
-            return False
-    return True
-
-
-def cpp_flag(compiler):
-    """Return the -std=c++[11/14/17] compiler flag.
-    The newer version is prefered over c++11 (when it is available).
-    """
-    flags = ['-std=c++17', '-std=c++14', '-std=c++11']
-
-    for flag in flags:
-        if has_flag(compiler, flag): return flag
-
-    raise RuntimeError('Unsupported compiler -- at least C++11 support '
-                       'is needed!')
-
-
-class BuildExt(build_ext):
-    """A custom build extension for adding compiler-specific options."""
-    c_opts = {
-        'msvc': ['/EHsc', '/permissive-'],
-        'unix': [],
-    }
-    l_opts = {
-        'msvc': [],
-        'unix': [],
-    }
-
-    if sys.platform == 'darwin':
-        darwin_opts = ['-stdlib=libc++', '-mmacosx-version-min=10.7']
-        c_opts['unix'] += darwin_opts
-        l_opts['unix'] += darwin_opts
-
-    def build_extensions(self):
-        ct = self.compiler.compiler_type
-        opts = self.c_opts.get(ct, [])
-        link_opts = self.l_opts.get(ct, [])
-        if ct == 'unix':
-            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
-            opts.append(cpp_flag(self.compiler))
-            if has_flag(self.compiler, '-fvisibility=hidden'):
-                opts.append('-fvisibility=hidden')
-        elif ct == 'msvc':
-            opts.append('/D_CRT_RAND_S')
-            opts.append('/DVERSION_INFO="%s"' % self.distribution.get_version())
-        for ext in self.extensions:
-            ext.extra_compile_args = opts
-            ext.extra_link_args = link_opts
-        build_ext.build_extensions(self)
-
-
 setup(
-    name=About.NAME,
-    version=About.VERSION,
-    description=About.DESCRIPTION,
+    name="vecxx",
+    version=__version__,
+    description="Vectorize some text",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
-    author=About.AUTHOR,
+    author="dpressel",
+    author_email="dpressel@gmail.com",
     python_requires='>=3.6',
     ext_modules=ext_modules,
     install_requires=["pybind11>=2.5.0"],
     extras_require={
         'test': ['pytest', 'pytest-forked'],
     },
-    cmdclass={'build_ext': BuildExt},
+    cmdclass={'build_ext': build_ext},
     package_data={
         'vecxx': [
             'include/vecxx/vecxx.h',

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ class BuildExt(build_ext):
                 opts.append('-fvisibility=hidden')
         elif ct == 'msvc':
             opts.append('/D_CRT_RAND_S')
-            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+            opts.append('/DVERSION_INFO="%s"' % self.distribution.get_version())
         for ext in self.extensions:
             ext.extra_compile_args = opts
             ext.extra_link_args = link_opts
@@ -101,7 +101,7 @@ setup(
     author=About.AUTHOR,
     python_requires='>=3.6',
     ext_modules=ext_modules,
-    install_requires=["pybind11>=2.8.0"],
+    install_requires=["pybind11>=2.5.0"],
     extras_require={
         'test': ['pytest', 'pytest-forked'],
     },

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def cpp_flag(compiler):
 class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
-        'msvc': ['/EHsc'],
+        'msvc': ['/EHsc', '/permissive-'],
         'unix': [],
     }
     l_opts = {

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ ext_modules = [
     Pybind11Extension("vecxx",
         ["src/vecxx.cpp"],
         include_dirs=["include"],
-        define_macros = [('VERSION_INFO', __version__)],
+        define_macros = [('VERSION_INFO', __version__),
+            ('_CRT_RAND_S', 1),],
         ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.build_ext import build_ext
 import pybind11
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 class About(object):

--- a/src/vecxx.cpp
+++ b/src/vecxx.cpp
@@ -2,13 +2,13 @@
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
 #include "vecxx/vecxx.h"
-
+#define STRINGIFY(x) #x
 namespace py = pybind11;
 
 PYBIND11_MODULE(vecxx, m) {
 
     #ifdef VERSION_INFO
-        m.attr("__version__") = VERSION_INFO;
+        m.attr("__version__") = STRINGIFY(VERSION_INFO);
     #else
         m.attr("__version__") = "dev";
     #endif

--- a/src/vecxx.cpp
+++ b/src/vecxx.cpp
@@ -9,6 +9,8 @@ PYBIND11_MODULE(vecxx, m) {
 
     #ifdef VERSION_INFO
         m.attr("__version__") = VERSION_INFO;
+    #else
+        m.attr("__version__") = "dev";
     #endif
     m.doc() = "pybind11 vecxx plugin";
     py::class_<Vocab>(m, "Vocab")

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -13,6 +13,28 @@ TEST_N_IDS_GOLD = [
     [1, 8, 158, 63, 10940, 525, 18637, 7, 3685, 5, 2],
     [1, 18, 14242, 1685, 2997, 4719, 2]
 ]
+def test_no_vocab():
+    caught = False
+    try:
+        bpe = BPEVocab(
+            vocab_file="i dont exist",
+            codes_file=os.path.join(TEST_DATA, "codes.30k")
+        )
+    except Exception as e:
+        caught = True
+    assert caught == True
+
+def test_no_codes():
+    caught = False
+    try:
+        bpe = BPEVocab(
+            vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
+            codes_file="i dont exist"
+        )
+    except Exception as e:
+        caught = True
+    assert caught == True 
+
 def test_pieces():
     bpe = BPEVocab(
         vocab_file=os.path.join(TEST_DATA, "vocab.30k"),


### PR DESCRIPTION
the C++ library was failing silently when
the codes or a vocab file was not found,
not initializing the values properly, yielding
ugly runtime issues.

Also added pytests to ensure that the runtime
errors are propagated properly through pybind
(as RuntimeErrors)