### PR TITLE
Feature/inverse lookup

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: vecxx
-  version: 0.0.4
+  version: 0.0.5
 
 source:
   path: ..

--- a/include/vecxx/iox.h
+++ b/include/vecxx/iox.h
@@ -559,7 +559,7 @@ public:
 	return std::make_tuple(false, (Index_T)0);
     }
 
-    std::tuple<bool, std::string> rfind(const Index_T idx) {
+    std::tuple<bool, std::string> rfind(const Index_T idx) const {
         if (idx >= this->size()) {
             throw std::runtime_error("PerfectHashMapStrInt::rfind index " + std::to_string(idx) + " out of range");
         }

--- a/include/vecxx/iox.h
+++ b/include/vecxx/iox.h
@@ -13,8 +13,12 @@
  *
  * For this library, we are targeting C++11 or later.
  */ 
+#include <cassert>
+#include <cstdint>
 #include <inttypes.h> /* PRIu32 PRIx32 */
 #include <stdint.h>   /* UINT32_MAX uint32_t uint64_t */
+#include <string>
+#include <tuple>
 #include "vecxx/phf.h"
 #include "utils.h"
 
@@ -309,32 +313,51 @@ void compile_str_int(const UnorderedMapStrInt& c, std::string dir,size_t alpha=8
     auto m = phf.m;
     save_phf(phf, dir);
 
+    std::vector<char> flat;
     uint32_t* h = new uint32_t[m];
     memset(h, 0, m*4);
     uint32_t* v = new uint32_t[m];
     memset(v, 0, m*4);
+    uint32_t* offsets = new uint32_t[m*2];
+    memset(offsets, 0, m*4*2);
 
+    uint32_t prev_offset = -1;
     for (auto p = c.begin(); p != c.end(); ++p) {
 	phf_hash_t idx = PHF::hash(&phf, p->first);
 	h[idx] = _hash_key(p->first);
 	v[idx] = (uint32_t)p->second;
-	
+        assert((uint32_t)p->second < m*2);
+        auto offset_start = (uint32_t)p->second * 2;
+        offsets[offset_start] = (uint32_t)flat.size();
+        for (const char& ch : p->first) {
+            flat.push_back(ch);
+        }
+        offsets[offset_start + 1] = (uint32_t)flat.size();
     }
     std::ofstream bin(file_in_dir(dir, "v.dat"),
 		      std::ios::out | std::ios::binary);
     bin.write((const char*)v, m*4);
     bin.close();
 
+    std::ofstream obin(file_in_dir(dir, "offsets.dat"),
+		       std::ios::out | std::ios::binary);
+    obin.write((const char*)offsets, m*4*2);
+    obin.close();
+
     std::ofstream hbin(file_in_dir(dir, "hkey.dat"),
 		       std::ios::out | std::ios::binary);
     hbin.write((const char*)h, m*4);
     hbin.close();
 
+    std::ofstream cbin(file_in_dir(dir, "flat.dat"),
+		       std::ios::out | std::ios::binary);
+    cbin.write((const char*)&flat[0], flat.size());
+    cbin.close();
+
     PHF::destroy(&phf);
     delete [] k;
     delete [] h;
     delete [] v;
-
 }
 
 void compile_str_str(const UnorderedMapStrStr& c, std::string dir, size_t alpha=80, size_t lambda=4) {
@@ -491,6 +514,11 @@ class PerfectHashMapStrInt : public MapStrInt
     uint32_t* _v;
     Handle_T _k_fd;
     Handle_T _v_fd;
+    uint32_t* _offsets;
+    Handle_T _offsets_fd;
+    uint32_t _data_len;
+    Handle_T _data_fd;
+    char* _data;
     uint32_t _hash_key(const std::string& k) const {
 	return phf_round32(k, 1337);
     }
@@ -499,6 +527,8 @@ public:
 	load_phf(_phf, dir);
 	std::tie(_k, _k_fd) = _read_uint32s(file_in_dir(dir, "hkey.dat"), _phf.m);
 	std::tie(_v, _v_fd) = _read_uint32s(file_in_dir(dir, "v.dat"), _phf.m);
+	std::tie(_offsets, _offsets_fd) = _read_uint32s(file_in_dir(dir, "offsets.dat"), _phf.m*2);
+	std::tie(_data, _data_len, _data_fd) = _read_chars(file_in_dir(dir, "flat.dat"));
     }
     ~PerfectHashMapStrInt() {
 	if (_k != NULL) {
@@ -521,21 +551,28 @@ public:
 	phf_hash_t idx = PHF::hash(&_phf, key);
         const uint32_t p = _v[idx];
 	if (_k[idx] == _hash_key(key)) {
+            auto offset_idx = p * 2;
+            auto offset_start = _offsets[offset_idx];
+            auto offset_end = _offsets[offset_idx + 1];
 	    return std::make_tuple(true, (Index_T)p);
 	}
 	return std::make_tuple(false, (Index_T)0);
     }
+
     std::tuple<bool, std::string> rfind(const Index_T idx) {
         if (idx >= this->size()) {
             throw std::runtime_error("PerfectHashMapStrInt::rfind index " + std::to_string(idx) + " out of range");
         }
-        // TODO
-        // return;
-        throw std::runtime_error("PerfectHashMapStrInt::rfind not implemented");
+        uint32_t offset_idx = (uint32_t)idx * 2;
+        auto offset_start = _offsets[offset_idx];
+        auto offset_end = _offsets[offset_idx + 1];
+        if (offset_end > _data_len) {
+            return std::make_tuple(false, "");
+        }
+        return std::make_tuple(true, std::string(&_data[offset_start], &_data[offset_end]));
     }
     size_t size() const { return _phf.m; }
     size_t max_size() const { return _phf.m; }
-    
 };
 
 

--- a/include/vecxx/iox.h
+++ b/include/vecxx/iox.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <tuple>
 #include "vecxx/phf.h"
-#include "utils.h"
+#include "vecxx/utils.h"
 
 #if defined(WIN32) || defined(_WIN32)
 #  include <windows.h>

--- a/include/vecxx/iox.h
+++ b/include/vecxx/iox.h
@@ -16,6 +16,7 @@
 #include <inttypes.h> /* PRIu32 PRIx32 */
 #include <stdint.h>   /* UINT32_MAX uint32_t uint64_t */
 #include "vecxx/phf.h"
+#include "utils.h"
 
 #if defined(WIN32) || defined(_WIN32)
 #  include <windows.h>
@@ -498,13 +499,12 @@ public:
 	load_phf(_phf, dir);
 	std::tie(_k, _k_fd) = _read_uint32s(file_in_dir(dir, "hkey.dat"), _phf.m);
 	std::tie(_v, _v_fd) = _read_uint32s(file_in_dir(dir, "v.dat"), _phf.m);
-	
     }
     ~PerfectHashMapStrInt() {
 	if (_k != NULL) {
 	    munmap(_k, _phf.m*4);
 	    close_file(_k_fd);
-	}	
+	}
 	if (_v != NULL) {
 	    munmap(_v, _phf.m*4);
 	    close_file(_v_fd);
@@ -524,6 +524,14 @@ public:
 	    return std::make_tuple(true, (Index_T)p);
 	}
 	return std::make_tuple(false, (Index_T)0);
+    }
+    std::tuple<bool, std::string> rfind(const Index_T idx) {
+        if (idx >= this->size()) {
+            throw std::runtime_error("PerfectHashMapStrInt::rfind index " + std::to_string(idx) + " out of range");
+        }
+        // TODO
+        // return;
+        throw std::runtime_error("PerfectHashMapStrInt::rfind not implemented");
     }
     size_t size() const { return _phf.m; }
     size_t max_size() const { return _phf.m; }

--- a/include/vecxx/utils.h
+++ b/include/vecxx/utils.h
@@ -106,16 +106,12 @@ public:
 	return std::make_tuple(true, it->second);
     }
     std::tuple<bool, std::string> rfind(const Index_T indx) {
-        auto begin = std::chrono::high_resolution_clock::now();
         if (_mr.empty()) {
             std::for_each(_m.begin(), _m.end(),
                     [this] (const std::pair<std::string, Index_T>& p) {
                         this->_mr[p.second] = p.first;
                     });
         }
-        auto end = std::chrono::high_resolution_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(end - begin);
-        std::cout << "convert time " << elapsed.count() << " microseconds" << std::endl;
         auto it = _mr.find(indx);
         if (it == _mr.end()) {
             return std::make_tuple(false, "");

--- a/include/vecxx/utils.h
+++ b/include/vecxx/utils.h
@@ -22,6 +22,7 @@ typedef std::unordered_map<std::string, uint32_t> SpecialVocab_T;
 typedef std::vector<int> VecList_T;
 typedef std::function<std::string(std::string)> Transform_T;
 
+const std::string WHITESPACE = " \n\r\t\f\v";
 
 class MapStrStr
 {
@@ -39,7 +40,7 @@ public:
     MapStrInt() {}
     virtual ~MapStrInt() {}
     virtual std::tuple<bool, Index_T> find(const std::string& key) const = 0;
-    virtual std::tuple<bool, std::string> rfind(const Index_T) = 0;
+    virtual std::tuple<bool, std::string> rfind(const Index_T) const = 0;
     virtual bool exists(const std::string& key) const = 0;
     virtual size_t size() const = 0;
     virtual size_t max_size() const = 0;
@@ -83,7 +84,7 @@ public:
 class UnorderedMapStrInt : public MapStrInt
 {
     std::unordered_map<std::string, Index_T> _m;
-    std::unordered_map<Index_T, std::string> _mr;
+    mutable std::unordered_map<Index_T, std::string> _mr;
 public:
     typedef typename std::unordered_map<std::string, Index_T>::const_iterator const_iterator;
     UnorderedMapStrInt() {
@@ -105,7 +106,7 @@ public:
 	}
 	return std::make_tuple(true, it->second);
     }
-    std::tuple<bool, std::string> rfind(const Index_T indx) {
+    std::tuple<bool, std::string> rfind(const Index_T indx) const {
         if (_mr.empty()) {
             std::for_each(_m.begin(), _m.end(),
                     [this] (const std::pair<std::string, Index_T>& p) {
@@ -187,6 +188,22 @@ void upper(std::string& data)
 {
     std::transform(data.begin(), data.end(), data.begin(),
 		   [](unsigned char c){ return std::toupper(c); });
+}
+
+std::string ltrim(const std::string &s)
+{
+    size_t start = s.find_first_not_of(WHITESPACE);
+    return (start == std::string::npos) ? "" : s.substr(start);
+}
+
+std::string rtrim(const std::string &s)
+{
+    size_t end = s.find_last_not_of(WHITESPACE);
+    return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+}
+
+std::string trim(const std::string &s) {
+    return rtrim(ltrim(s));
 }
 
 #endif

--- a/include/vecxx/utils.h
+++ b/include/vecxx/utils.h
@@ -9,7 +9,6 @@
 #include <unordered_map>
 #include <algorithm>
 #include <functional>
-#include <chrono>
 
 typedef uint32_t Index_T;
 

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <functional>
 #include <exception>
+#include <chrono>
+
 #include "vecxx/utils.h"
 #include "vecxx/bpe.h"
 
@@ -346,8 +348,11 @@ public:
 	    special_tokens[token] = _offset;
 	    ++_offset;
 	}
-	   
+        auto _begin = std::chrono::high_resolution_clock::now();
 	vocab = read_vocab_file(vocab_file, _offset);
+        auto _end = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(_end - _begin);
+        std::cout << "vocab load time " << elapsed.count() << " microseconds" << std::endl;
 	read_codes_file(codes_file, _codes, _reversed_codes);
     }
     virtual ~BPEVocab() {
@@ -394,6 +399,16 @@ public:
 	}
 
 	return x;	
+    }
+
+    virtual std::string rlookup(const Index_T& idx) {
+        bool found;
+        std::string rv;
+        std::tie(found, rv) = vocab->rfind(idx);
+        if (!found) {
+            return "";
+        }
+        return rv;
     }
 
     // FIXME: pass return by ref

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -349,11 +349,7 @@ public:
 	    special_tokens[token] = _offset;
 	    ++_offset;
 	}
-        auto _begin = std::chrono::high_resolution_clock::now();
 	vocab = read_vocab_file(vocab_file, _offset);
-        auto _end = std::chrono::high_resolution_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(_end - _begin);
-        std::cout << "vocab load time " << elapsed.count() << " microseconds" << std::endl;
 	read_codes_file(codes_file, _codes, _reversed_codes);
     }
     virtual ~BPEVocab() {

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -2,6 +2,7 @@
 #define __VECXX_H__
 
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -12,7 +12,6 @@
 #include <algorithm>
 #include <functional>
 #include <exception>
-#include <chrono>
 
 #include "vecxx/utils.h"
 #include "vecxx/bpe.h"

--- a/include/vecxx/vecxx.h
+++ b/include/vecxx/vecxx.h
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <cassert>
@@ -127,6 +128,7 @@ public:
     virtual std::string end_str() const = 0;
     virtual std::string unk_str() const = 0;
     virtual void compile_vocab(const std::string& target_dir) const = 0;
+    virtual std::string rlookup(const Index_T&) const = 0;
 
 };
 class WordVocab : public Vocab
@@ -301,6 +303,10 @@ public:
 	return output;
     }
 
+    virtual std::string rlookup(const Index_T& id) const {
+        throw std::logic_error("WordVocab::rlookup not implemented");
+    }
+
     
 };
 
@@ -398,7 +404,7 @@ public:
 	return x;	
     }
 
-    virtual std::string rlookup(const Index_T& idx) {
+    virtual std::string rlookup(const Index_T& idx) const {
         bool found;
         std::string rv;
         std::tie(found, rv) = vocab->rfind(idx);
@@ -484,6 +490,26 @@ public:
 	    }
 	}
 	return std::make_tuple(ids, lengths);
+    }
+
+    std::string decode(const VecList_T& ids) const {
+        // reverse look up each ids
+        std::vector<std::string> tokens;
+        for (const auto & id : ids) {
+            tokens.push_back(this->_vocab->rlookup(id));
+        }
+        std::string rv;
+        std::string separator = "@@";
+        for (auto & s : tokens) {
+            auto found_pos = s.find(separator);
+            if (found_pos != std::string::npos) {
+                s.replace(found_pos, 2, "");
+                rv = rv + s;
+                continue;
+            }
+            rv += s + " ";
+        }
+        return ltrim(rtrim(rv));
     }
 };
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 # The main interface is through Pybind11Extension.
 # * You can add cxx_std=11/14/17, and then build_ext can be removed.

--- a/src/vecxx.cpp
+++ b/src/vecxx.cpp
@@ -120,6 +120,7 @@ PYBIND11_MODULE(vecxx, m) {
 	   py::arg("emit_begin_tok")=TokenList_T(),
 	   py::arg("emit_end_tok")=TokenList_T()
 	   )
+      .def("decode", &VocabVectorizer::decode)
       .def("piece_to_id", &VocabVectorizer::piece_to_id)
       .def("convert_to_pieces", &VocabVectorizer::convert_to_pieces,
 	   py::arg("tokens")

--- a/src/vecxx.cpp
+++ b/src/vecxx.cpp
@@ -34,6 +34,7 @@ PYBIND11_MODULE(vecxx, m) {
 	   
 	   )
       .def("lookup", &BPEVocab::lookup)
+      .def("rlookup", &BPEVocab::rlookup)
       .def("compile_vocab", &BPEVocab::compile_vocab)
       .def_property_readonly("pad_id", &BPEVocab::pad_id)
       .def_property_readonly("start_id", &BPEVocab::start_id)

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -13,6 +13,7 @@ TEST_N_IDS_GOLD = [
     [1, 8, 158, 63, 10940, 525, 18637, 7, 3685, 5, 2],
     [1, 18, 14242, 1685, 2997, 4719, 2]
 ]
+TEST_REVERSE_GOLD = ['', 'my', 'name', 'is', 'dan', '.', 'i', 'am', 'from', 'ann', 'ar@@', 'bor', ',', 'michigan', ',', 'in', 'wash@@', 'ten@@', 'aw', 'county', '']
 def test_no_vocab():
     caught = False
     try:
@@ -83,6 +84,21 @@ def test_ids():
     v, l = vec.convert_to_ids(TEST_SENTENCE.split(), 5)
     assert v == TEST_IDS_GOLD[:5]
     assert l == 5
+
+def test_ids_reverse():
+    bpe = BPEVocab(
+        vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
+        codes_file=os.path.join(TEST_DATA, "codes.30k")
+    )
+    vec = VocabVectorizer(bpe, transform=str.lower, emit_begin_tok=["<GO>"], emit_end_tok=["<EOS>"])
+    v, l = vec.convert_to_ids(TEST_SENTENCE.split())
+    assert v == TEST_IDS_GOLD
+    assert l == len(TEST_IDS_GOLD)
+    tok = []
+    for i in v:
+        tok.append(bpe.rlookup(i))
+    assert tok == TEST_REVERSE_GOLD
+
 
 def test_ids_stack():
     bpe = BPEVocab(

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -65,7 +65,22 @@ def test_bpe_lookup():
     ids = [bpe.lookup(s, str.lower) for s in toks]
     assert ids == TEST_IDS_GOLD
 
-    
+def test_compile():
+    bpe = BPEVocab(
+        vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
+        codes_file=os.path.join(TEST_DATA, "codes.30k")
+    )
+    compiled_path = os.path.join(TEST_DATA, "vocab.30k.ph")
+    bpe.compile_vocab(compiled_path)
+    bpe = BPEVocab(
+        vocab_file=compiled_path,
+        codes_file=compiled_path
+    )
+    vec = VocabVectorizer(bpe, transform=str.lower, emit_begin_tok=["<GO>"], emit_end_tok=["<EOS>"])
+    v, l = vec.convert_to_ids(TEST_SENTENCE.split())
+    assert v == TEST_IDS_GOLD
+    assert l == len(TEST_IDS_GOLD)
+
 def test_ids():
     bpe = BPEVocab(
         vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
@@ -99,6 +114,23 @@ def test_ids_reverse():
         tok.append(bpe.rlookup(i))
     assert tok == TEST_REVERSE_GOLD
 
+def test_ids_reverse_ph():
+    bpe = BPEVocab(
+        vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
+        codes_file=os.path.join(TEST_DATA, "codes.30k")
+    )
+    compiled_path = os.path.join(TEST_DATA, "vocab.30k.ph")
+    bpe.compile_vocab(compiled_path)
+    bpe = BPEVocab(
+        vocab_file=compiled_path,
+        codes_file=compiled_path
+    )
+    vec = VocabVectorizer(bpe, transform=str.lower, emit_begin_tok=["<GO>"], emit_end_tok=["<EOS>"])
+    v, l = vec.convert_to_ids(TEST_SENTENCE.split())
+    decoded = vec.decode(v)
+    assert decoded == TEST_SENTENCE.lower()
+    assert v == TEST_IDS_GOLD
+    assert l == len(TEST_IDS_GOLD)
 
 def test_ids_stack():
     bpe = BPEVocab(


### PR DESCRIPTION
Add ability to go from ids to string for bpe vocab. Eg
```
TEST_SENTENCE = "My name is Dan . I am from Ann Arbor , Michigan , in Washtenaw County"
 bpe = BPEVocab(
    vocab_file=os.path.join(TEST_DATA, "vocab.30k"),
    codes_file=os.path.join(TEST_DATA, "codes.30k")
 )
vec = VocabVectorizer(...)
v, l = vec.convert_to_ids(TEST_SENTENCE.split())
tok = []
for i in v:
    tok.append(bpe.rlookup(i))
# tok = ['', 'my', 'name', 'is', 'dan', '.', 'i', 'am', 'from', 'ann', 'ar@@', 'bor', ',', 'michigan', ',', 'in', 'wash@@', 'ten@@', 'aw', 'county', '']

decoded = vec.decode(v)
assert decoded == TEST_SENTENCE.lower() # true
```
* Implemented the reverse find `rfind` for both `PerfectHashMapStrInt` and `UnorderedMapStrInt`.
* Implemented reverse lookup `rlookup` for `BPEVocab`
* Implemented `decode` for `VocabVectorizer`
* Added tests.
* Bump version to 0.0.5